### PR TITLE
fix: reorder secret letters in Lab 1 to match instructions and reveal correct word

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,7 +8,7 @@ android {
     compileSdk 36
 
     defaultConfig {
-        applicationId "com.driuft.androidhunt" // [J]
+        applicationId "com.driuft.androidhunt" // [P]
         minSdk 21
         targetSdk 32
         versionCode 1

--- a/app/src/main/java/com/driuft/androidhunt/MainActivity.kt
+++ b/app/src/main/java/com/driuft/androidhunt/MainActivity.kt
@@ -4,7 +4,7 @@ import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 
 /**
- * [T]
+ * [J]
  */
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -6,7 +6,7 @@
     android:layout_height="match_parent"
     tools:context=".MainActivity">
 
-    <!-- [P] -->
+    <!-- [C] -->
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -12,7 +12,7 @@
         <!-- Status bar color. -->
         <item name="android:statusBarColor">?attr/colorPrimaryVariant</item>
 
-        <!-- [C] -->
+        <!-- [T] -->
 
     </style>
 </resources>


### PR DESCRIPTION
Adjusted the order of secret letters in the Lab 1 scavenger hunt so that they now align with the instructions and correctly spell out the intended secret word. This ensures the activity flows as expected and avoids student confusion.
